### PR TITLE
bump version to 0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-## [0.1.1] - 2026-04-26
+## [0.1.1] - 2026-04-29
 
 ### Added
 - `AgentAnvilError` exception hierarchy (`BackendError`, `RunnerError`,


### PR DESCRIPTION
Ships [0.1.1](https://github.com/cchinchilla-dev/agentanvil/blob/release/0.1.1/CHANGELOG.md#011---2026-04-29).

Highlights:
- `LLMBackend` ABC + `DirectBackend` (httpx-only OpenAI/Anthropic/Google) — portability target.
- Record/replay envelope (schema v1): `RecordingBackend`, `MockBackend`, bit-for-bit determinism CI test.
- `Runner` ABC with `SubprocessRunner` (JSON-over-stdin/stdout, `anyio.fail_after` timeouts).
- Core trace models (`Trace`, `Step` variants), `RunRecord`/`RunMetadata`, `Report`/`ReportFormat`.
- `AgentAnvilError` hierarchy, `py.typed` marker, coverage gate at 85%.
- `version-linearity` and `determinism` CI jobs.